### PR TITLE
docs: Standardize the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 HTTP Client
 ==============
 
-This repository holds all interfaces related to [PSR-18 (HTTP Client)][psr-url].
+This repository holds all the common code related to [PSR-18 (HTTP Client)][psr-url].
 
-Note that this is not a HTTP Client implementation of its own. It is merely interfaces that describe the components of a HTTP Client.
+Note that this is not a HTTP Client implementation of its own. It is merely abstractions that describe the components of a HTTP Client.
 
 You can find [implementations][implementation-url] and [installation instructions][package-url] for the specification on the packagist.
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
-PSR Http Client
-===============
+HTTP Client
+==============
 
-This repository holds all interfaces/classes/traits related to
-[PSR-18](http://www.php-fig.org/psr/psr-18/).
+This repository holds all interfaces related to [PSR-18 (HTTP Client)][psr-url].
 
-Note that this is not an HTTP client implementation of its own. It is merely an
-interface that describes an HTTP client. See 
-[the specification](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-18-http-client.md)
-for more details.
+Note that this is not a HTTP Client implementation of its own. It is merely interfaces that describe the components of a HTTP Client.
 
-You can find implementations of the specification by looking for packages providing 
-the [psr/http-client-implementation](https://packagist.org/providers/psr/http-client-implementation)
-virtual package.
+You can find [implementations][implementation-url] and [installation instructions][package-url] for the specification on the packagist.
+
+[psr-url]: http://www.php-fig.org/psr/psr-18
+[package-url]: https://packagist.org/packages/psr/http-client
+[implementation-url]: https://packagist.org/providers/psr/http-client-implementation

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 HTTP Client
-==============
+===========
 
 This repository holds all the common code related to [PSR-18 (HTTP Client)][psr-url].
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository holds all the common code related to [PSR-18 (HTTP Client)][psr-
 
 Note that this is not a HTTP Client implementation of its own. It is merely abstractions that describe the components of a HTTP Client.
 
-You can find [implementations][implementation-url] and [installation instructions][package-url] for the specification on the packagist.
+The installable [package][package-url] and [implementations][implementation-url] are listed on Packagist.
 
 [psr-url]: http://www.php-fig.org/psr/psr-18
 [package-url]: https://packagist.org/packages/psr/http-client


### PR DESCRIPTION
What:
Standardizes the README file providing a common language and an implementation link.

Why:
There are differences between PSR's READMEs in regarding language and the lacking of implementations references. So I've updated all READMEs using the https://github.com/php-fig/http-factory as base.